### PR TITLE
Update pp.py

### DIFF
--- a/custom_components/phyn/devices/pp.py
+++ b/custom_components/phyn/devices/pp.py
@@ -157,9 +157,10 @@ class PhynConsumptionSensor(PhynEntity, SensorEntity):
 class PhynCurrentFlowRateSensor(PhynEntity, SensorEntity):
     """Monitors the current water flow rate."""
 
-    _attr_native_unit_of_measurement = "gpm"
-    _attr_state_class: SensorStateClass = SensorStateClass.MEASUREMENT
+    _attr_state_class: SensorStateClass = SensorStateClass.TOTAL
     _attr_translation_key = "current_flow_rate"
+    _attr_device_class = SensorDeviceClass.WATER
+    _attr_native_unit_of_measurement = UnitOfVolume.GALLONS
 
     def __init__(self, device):
         """Initialize the flow rate sensor."""


### PR DESCRIPTION
Added device class (water)
Changed unit of measurement to "UnitOfVolume.GALLONS"

These changes allows to change the unit of measurement in Home Assistant to preferred unit (liters, cubic meters, gallons...) for current water flow. 

Changed state class from measurement to total 

This is done as basis of Home Assistant development documentation, measurement should not be used for current measurment.